### PR TITLE
File removal

### DIFF
--- a/fields/types/file/FileType.js
+++ b/fields/types/file/FileType.js
@@ -69,10 +69,16 @@ file.prototype.reset = function (item) {
 /**
  * Deletes the stored file and resets the field value
  */
-// TODO: Should we accept a callback here? Seems like a good idea.
-file.prototype.remove = function (item) {
-	this.storage.removeFile(item.get(this.path));
-	this.reset();
+file.prototype.remove = function (item, callback) {
+    var field = this;
+	this.storage.removeFile(item.get(this.path), function(err){
+	    if(err){
+	        callback(err);
+	    } else{
+	        field.reset(item); //must take in the item to reset
+	        callback();
+	    }
+	});
 };
 
 /**
@@ -155,10 +161,12 @@ file.prototype.updateItem = function (item, data, files, callback) {
 	var value = this.getValueFromData(data);
 	var uploadedFile;
 
-	// Providing the string "remove" removes the file and resets the field
-	if (value === 'remove') {
-		this.remove(item);
-		utils.defer(callback);
+	// Providing the string "delete" removes the file and resets the field
+	// "delete" is used to bring it in line with what validateInput expects.
+	if (value === 'delete') {
+		this.remove(item, callback);
+		//hard return here to prevent callback from being invoked twice. 
+		return;
 	}
 
 	// Find an uploaded file in the files argument, either referenced in the

--- a/fields/types/file/FileType.js
+++ b/fields/types/file/FileType.js
@@ -70,14 +70,14 @@ file.prototype.reset = function (item) {
  * Deletes the stored file and resets the field value
  */
 file.prototype.remove = function (item, callback) {
-    var field = this;
-	this.storage.removeFile(item.get(this.path), function(err){
-	    if(err){
-	        callback(err);
-	    } else{
-	        field.reset(item); //must take in the item to reset
-	        callback();
-	    }
+	var field = this;
+	this.storage.removeFile(item.get(this.path), function (err) {
+		if (err) {
+			callback(err);
+		} else {
+			field.reset(item); // must take in the item to reset
+			callback();
+		}
 	});
 };
 
@@ -165,7 +165,7 @@ file.prototype.updateItem = function (item, data, files, callback) {
 	// "delete" is used to bring it in line with what validateInput expects.
 	if (value === 'delete') {
 		this.remove(item, callback);
-		//hard return here to prevent callback from being invoked twice. 
+		// hard return here to prevent callback from being invoked twice.
 		return;
 	}
 


### PR DESCRIPTION
Changed the file field type so that it can remove files. With these changes, one can pass "delete" as the value of a file field to delete a file. For example, if the schema looks like this:
````````
let keystone = require('keystone');
let util = require('util');
let Types = keystone.Field.Types;

let ModelA = new keystone.List('ModelA', {track: true});

let localStorage = new keystone.Storage({
	adapter: keystone.Storage.Adapters.FS,
	fs: {
	    //MUST start with ./public
		path: keystone.expandPath('./public/model_a/files'),
		//Must NOT start with /public
		//MUST begin and end in a slash
		publicPath: '/model_a/files/',
	}, schema: {
            size: true,
            mimetype: true,
            path: true,
            originalname: true,
            url: true,
	}
});

ModelA.add({
	value: {
		type: Types.File,
		storage: localStorage,
		initial: false,
	},

	description: {
	    type: Types.Text,
	    initial: true
	},
	
	// other fields omitted for clarity
});


/**
 * Registration
 */
ModelA.register();
module.exports = ModelA;
````````
then one can POST the following to http://${YOUR_KEYSTONE_SERVER_HERE}/keystone/api/model-as/${ID_OF_MODEL_A_INSTANCE} to delete the file:
````````
{
     value: "delete",
     //other fields omitted for clarity
}
````````